### PR TITLE
ci: add basic ci and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: Full CI Chronos Workflow
+
+on: 
+  push: 
+    branches: 
+      ["main"]
+  pull_request:
+    branches:
+      ["main"]
+
+  workflow_dispatch:
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+permissions:
+  contents: write
+    
+jobs: 
+  ci-backend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest version of code
+        uses: actions/checkout@v3
+      
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Build
+        run: go build .
+
+      - name: Test
+        run: go test tests/
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: backend
+          path: chronos
+          retation-days: 10
+  
+  release:
+    runs-on: ubuntu-latest
+    needs: ci-backend
+    steps:
+      - name: Get latest version of code
+        uses: actions/checkout@v3
+      
+      - name: Download Artifact 
+        uses: actions/download-artifact@v2
+        with:
+          name: backend
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Setup semantic-release
+        run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog -D
+
+      - name: Run semantic-release
+        run: npx semantic-release
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.db
+chronos

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,28 @@
+{
+  "branches": "main",
+  "repositoryUrl": "https://github.com/jotaEspig/chronos",
+  "debug": "false",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Semantic Versioning Changelog"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"]
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": ["chronos"]
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
add github workflow file with a script for building and release on  pull-requests and pushes to the main branch